### PR TITLE
Update autoupdate upstream URL in manifest.toml for dodock

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -73,6 +73,8 @@ ram.runtime = "512M"
         prefetch = true
 
         autoupdate.strategy = "latest_gitlab_release"
+        autoupdate.upstream = "https://gitlab.com/dokos/dodock"
+
 
         [resources.sources.main]
         url = "https://gitlab.com/dokos/dokos/-/archive/v4.64.3/dokos-v4.64.3.tar.gz"


### PR DESCRIPTION
Autoupdate CI is failing because it is missing the right upstream repo for dodock e.g. see this commit https://github.com/YunoHost-Apps/Dokos_ynh/pull/140/commits/9a80d89698de66c3ae1d3cca588ca421d4c4f147

@Thatoo 